### PR TITLE
Add A CI Pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,58 @@
+name: Pipeline
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
+
+      - name: Cache cargo build
+        uses: actions/cache@v3
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-
+
+      - name: Install dependencies
+        run: cargo fetch
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run Tests
+        run: cargo test --all-targets --all-features
+
+      - name: Check SemVer compatibility
+        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,8 +48,13 @@ jobs:
       - name: Install dependencies
         run: cargo fetch
 
+      - name: Print the version used in the tools
+        run: |
+          cargo --version
+          cargo clippy --version
+
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --no-deps --all-targets --all-features -- -D warnings
 
       - name: Run Tests
         run: cargo test --all-targets --all-features

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Pipeline
+name: Build, Test and Lint Rust
 on:
   push:
     branches:
@@ -12,38 +12,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry
-        uses: actions/cache@v3
+      - name: Cache cargo artifacts
+        uses: actions/cache@v4
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-
-
-      - name: Cache cargo index
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-index-
-
-      - name: Cache cargo build
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install dependencies
         run: cargo fetch
@@ -58,6 +39,3 @@ jobs:
 
       - name: Run Tests
         run: cargo test --all-targets --all-features
-
-      - name: Check SemVer compatibility
-        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/src/commands/images/animal.rs
+++ b/src/commands/images/animal.rs
@@ -2,6 +2,7 @@ use std::ops::Range;
 
 use poise::serenity_prelude::CreateEmbed;
 use poise::{command, CreateReply};
+#[cfg(not(test))]
 use rand::{thread_rng, Rng};
 use serde::Deserialize;
 
@@ -121,7 +122,7 @@ mod tests {
             API_CHOICE.store(i, SeqCst);
             get_random_image("", "")
                 .await
-                .expect(&format!("Failed to get random image from API {}", i));
+                .unwrap_or_else(|_| panic!("Failed to get random image from API {}", i));
         }
     }
 }


### PR DESCRIPTION
I have added a CI pipeline that will do the usual checks of linting through clippy and testing. The current state of the repository does not pass the pipeline, but those fixes should probably be addressed in a separate PR. Also you could maybe consider adding a CD step that automatically deploys your bot on changes to `main`.